### PR TITLE
Added ability to set the pin anchor point via Xamarin AnchorX and AnchorY properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 .DS_Store
 xcuserdata*
 .userprefs
+*.userprefs
 /packages/
+packages/
 !packages/repositories.config
 bin
 obj

--- a/Demo.Forms/Sample1/S1PinView.xaml
+++ b/Demo.Forms/Sample1/S1PinView.xaml
@@ -3,6 +3,8 @@
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
 			 WidthRequest="37" 
 			 HeightRequest="48"
+			 AnchorX="0.5"
+			 AnchorY="1.0"
 			 x:Class="Demo.Forms.S1PinView">
 
 	<AbsoluteLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">

--- a/README.md
+++ b/README.md
@@ -55,7 +55,24 @@ protected override void OnCreate (Bundle bundle)
 </ContentPage>
 ```
 
-4) On the .cs of the page, when the map is created, setup the delegates to return the related views for the pin and the window.
+4) Create a class for your Pin view either using Xaml or code:
+```c#
+<StackLayout xmlns="http://xamarin.com/schemas/2014/forms" 
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+			 WidthRequest="37" 
+			 HeightRequest="48"
+			 AnchorX="0.5"
+			 AnchorY="1.0"
+			 x:Class="Demo.Forms.S1PinView">
+	<AbsoluteLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
+		<Image Source="pin_red.png" 
+			AbsoluteLayout.LayoutBounds="0, 0, 37, 48"
+			AbsoluteLayout.LayoutFlags="None" />
+	</AbsoluteLayout>
+</StackLayout>
+```
+
+5) On the .cs of the page, when the map is created, setup the delegates to return the related views for the pin and the window.
 
 ```c#
 public S1Page ()
@@ -64,7 +81,7 @@ public S1Page ()
 
 	// set the delegate to return the pinView
 	this.Map.GetPinViewDelegate = delegate (WPin pin) {
-		var pinView = new PinView(); // can be a user control or whatever
+		var pinView = new S1PinView(); // can be a user control or whatever
 		return pinView;
 	};
 

--- a/Wapps.Forms.Map.Droid/WMapRenderer.cs
+++ b/Wapps.Forms.Map.Droid/WMapRenderer.cs
@@ -57,6 +57,7 @@ namespace Wapps.Forms.Droid
 
 					if (MapControl.GetPinViewDelegate != null) {
 						var formsView = MapControl.GetPinViewDelegate (pin);
+						marker = marker.Anchor((float) formsView.AnchorX, (float) formsView.AnchorY);
 						//var nativeView = Utils.ConvertFormsToNative (formsView, new Rectangle (0, 0, (double)Utils.DpToPx ((float)formsView.WidthRequest), (double)Utils.DpToPx ((float)formsView.HeightRequest)));
 						var nativeView = WMapAuxiliarRenderer.LiveMapRenderer.GetNativeView(formsView);
 						Utils.FixImageSourceOfImageViews (nativeView as Android.Views.ViewGroup);

--- a/Wapps.Forms.Map.iOS/WMapRenderer.cs
+++ b/Wapps.Forms.Map.iOS/WMapRenderer.cs
@@ -48,7 +48,7 @@ namespace Wapps.Forms.iOS
 		{
 			MKAnnotationView annotationView = null;
 
-			if (annotation is MKUserLocation)
+			if (!(annotation is MKPointAnnotation))
 				return null;
 
 			var pin = GetPin (annotation as MKPointAnnotation);
@@ -74,6 +74,7 @@ namespace Wapps.Forms.iOS
 
 			annotationView = mapView.DequeueReusableAnnotation (pin.Id);
 			if (annotationView == null) {
+				annotationView = new WPinAnnotationView(annotation, pin.Id);
 
 				UIImage image = null;
 				if (MapControl.GetPinViewDelegate != null) {
@@ -81,9 +82,8 @@ namespace Wapps.Forms.iOS
 					var nativeView = Utils.ConvertFormsToNative (formsView, new CGRect (0, 0, formsView.WidthRequest, formsView.HeightRequest));
 					nativeView.BackgroundColor = UIColor.Clear;
 					image = Utils.ConvertViewToImage (nativeView);
+					annotationView.CenterOffset = new CGPoint((formsView.WidthRequest / 2) - formsView.AnchorX, (formsView.HeightRequest/2) - formsView.AnchorY);
 				}
-
-				annotationView = new WPinAnnotationView (annotation, pin.Id);
 				annotationView.CanShowCallout = false;
 				annotationView.Image = image;
 				((WPinAnnotationView)annotationView).Id = pin.Id;

--- a/Wapps.Forms.Map.iOS/WMapRenderer.cs
+++ b/Wapps.Forms.Map.iOS/WMapRenderer.cs
@@ -82,7 +82,7 @@ namespace Wapps.Forms.iOS
 					var nativeView = Utils.ConvertFormsToNative (formsView, new CGRect (0, 0, formsView.WidthRequest, formsView.HeightRequest));
 					nativeView.BackgroundColor = UIColor.Clear;
 					image = Utils.ConvertViewToImage (nativeView);
-					annotationView.CenterOffset = new CGPoint((formsView.WidthRequest / 2) - formsView.AnchorX, (formsView.HeightRequest/2) - formsView.AnchorY);
+					annotationView.CenterOffset = new CGPoint(formsView.WidthRequest * (0.5 - formsView.AnchorX), formsView.HeightRequest * (0.5 - formsView.AnchorY));
 				}
 				annotationView.CanShowCallout = false;
 				annotationView.Image = image;


### PR DESCRIPTION
This change fixes an issue where the anchor point on iOS and Android were different, where Android was correct but iOS was not. To solve this, this pull request uses the Xamarin Anchor properties (https://developer.xamarin.com/api/property/Xamarin.Forms.VisualElement.AnchorX/) to specify the anchor in the view itself, which then is honored by both Android and iOS. The AnchorX and AnchorY properties go from 0.0 to 1.0 with a default of 0.5. To set the anchor to the bottom middle, set AnchorX to 0.5 and AnchorY to 1.0. The demo has been updated to reflect this.

BREAKING CHANGE: Existing Android apps would need to at least add AnchorY="1.0" to maintain original behavior.

Also fixed an issue on iOS where it the user location is showing then we get a crash since the user location is an MKAnnotationWrapper on iOS.
